### PR TITLE
Fix installation instructions in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,15 +13,15 @@ An MCP (Model Context Protocol) server that provides tools for searching and ana
 
 ## Installation
 
-1. Install dependencies:
-```bash
-uv pip install -e .
-```
-
-2. Clone this repository:
+1. Clone this repository:
 ```bash
 git clone https://github.com/bwads001/cc-session-search.git
 cd cc-session-search
+```
+
+2. Install dependencies:
+```bash
+uv pip install -e .
 ```
 
 3. Add to Claude Code MCP config (`~/.config/claude/mcp.json`):


### PR DESCRIPTION
Maybe I'm missing something, or maybe I'm trying to contribute prematurely - surely you want to clone the repo first, then cd and install the dependencies, no?

I think probably this is premature - I think this needs a script entry point defined in the pyproject.toml.

If you have that, you could also run it with `uvx --from <repo> ...` and skip installation entirely.